### PR TITLE
fix for tensorflow 2.4.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,17 +2,18 @@
 
 Phoenics Bayesian optimizer
 Copyright 2018, Harvard University
-Copyright 2019, ChemOS Inc.
+Copyright 2020, Atinary Technologies
 
-This product includes software developed at ChemOS Inc. but is based on 
-certain software code developed at the Department of Chemistry and 
-Chemical Biology at Harvard University by the founders of ChemOS Inc.
+This product includes software developed at Atinary Technologies but is 
+based on certain software code developed at the Department of Chemistry 
+and Chemical Biology at Harvard University by the founders of Atinary 
+Technologies.
 
 The product includes software code developed at the Department of 
 Chemistry and Chemical Biology at Harvard University. All of such code 
 developed at Harvard University ("Harvard Code") was released under the 
 Apache 2.0 license by Harvard University 
 (see https://github.com/aspuru-guzik-group/phoenics).
-ChemOS Inc. has rewritten much of the Harvard Code, has improved it and 
-has added new functionalities.
+Atinary Technologies has rewritten much of the Harvard Code, has improved 
+it and has added new functionalities.
 

--- a/src/phoenics/BayesianNetwork/TfprobInterface/tfprob_interface.py
+++ b/src/phoenics/BayesianNetwork/TfprobInterface/tfprob_interface.py
@@ -31,8 +31,8 @@ import pickle
 import numpy                  as np 
 import tensorflow             as tf 
 import tensorflow_probability as tfp
+import edward2 as ed
 
-from tensorflow_probability import edward2 as ed
 from tensorflow_probability import distributions as tfd
 
 import os, sys


### PR DESCRIPTION
edward2 is now a library itself, and not a class within tensorflow.